### PR TITLE
chore(#1): rename to const-addrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "net-macros"
+name = "const-addrs"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# net-macros
+# const-addrs
 
 A set of macros for creating networking types from a string literal.
 
 ```rust
 use std::net::Ipv4Addr;
-use net_macros::ip4;
+use const_addrs::ip4;
 
 let a = ip4!("192.168.1.1");
 let b = Ipv4Addr::new(192,168,1,1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ```rust
 //! use std::net::Ipv4Addr;
-//! use net_macros::ip4;
+//! use const_addrs::ip4;
 //!
 //! # fn main() {
 //! let a = ip4!("192.168.1.1");
@@ -27,7 +27,7 @@
 //! For example:
 //! ```rust
 //! # use std::net::Ipv4Addr;
-//! # use net_macros::ip;
+//! # use const_addrs::ip;
 //!
 //! # fn main() {
 //! let val = ip!("192.168.1.1");
@@ -48,7 +48,7 @@
 //! For example:
 //! ```rust
 //! # use std::net::Ipv4Addr;
-//! # use net_macros::net;
+//! # use const_addrs::net;
 //!
 //! # fn main() {
 //! let val = net!("192.168.1.1/24");

--- a/tests/fail/ip.rs
+++ b/tests/fail/ip.rs
@@ -1,4 +1,4 @@
-use net_macros::ip;
+use const_addrs::ip;
 
 fn main() {
     let a = ip!("192.168.11");

--- a/tests/fail/ip4.rs
+++ b/tests/fail/ip4.rs
@@ -1,4 +1,4 @@
-use net_macros::ip4;
+use const_addrs::ip4;
 
 fn main() {
     let a = ip4!("192.168.11");

--- a/tests/fail/ip6.rs
+++ b/tests/fail/ip6.rs
@@ -1,4 +1,4 @@
-use net_macros::ip6;
+use const_addrs::ip6;
 
 fn main() {
     let a = ip6!("2001:db8::32::23");

--- a/tests/fail/mac.rs
+++ b/tests/fail/mac.rs
@@ -1,4 +1,4 @@
-use net_macros::mac;
+use const_addrs::mac;
 
 fn main() {
     let a = mac!("ca:fe:ca:fe");

--- a/tests/fail/mac6.rs
+++ b/tests/fail/mac6.rs
@@ -1,4 +1,4 @@
-use net_macros::mac6;
+use const_addrs::mac6;
 
 fn main() {
     let a = mac6!("ca:fe:ca:fe:c0:ff:ee");

--- a/tests/fail/mac8.rs
+++ b/tests/fail/mac8.rs
@@ -1,4 +1,4 @@
-use net_macros::mac8;
+use const_addrs::mac8;
 
 fn main() {
     let a = mac8!("ca:fe:ca:fe:ca:fe");

--- a/tests/fail/net.rs
+++ b/tests/fail/net.rs
@@ -1,4 +1,4 @@
-use net_macros::net;
+use const_addrs::net;
 
 fn main() {
     let a = net!("192.168.1.1/300");

--- a/tests/fail/net4.rs
+++ b/tests/fail/net4.rs
@@ -1,4 +1,4 @@
-use net_macros::net4;
+use const_addrs::net4;
 
 fn main() {
     let a = net4!("192.168.1.1/300");

--- a/tests/fail/net6.rs
+++ b/tests/fail/net6.rs
@@ -1,4 +1,4 @@
-use net_macros::net6;
+use const_addrs::net6;
 
 fn main() {
     let a = net6!("2001:db8::32::23/129");

--- a/tests/fail/sock.rs
+++ b/tests/fail/sock.rs
@@ -1,4 +1,4 @@
-use net_macros::sock;
+use const_addrs::sock;
 
 fn main() {
     let a = sock!("192.168.11:300");

--- a/tests/fail/sock4.rs
+++ b/tests/fail/sock4.rs
@@ -1,4 +1,4 @@
-use net_macros::sock4;
+use const_addrs::sock4;
 
 fn main() {
     let a = sock4!("192.168.11:300");

--- a/tests/fail/sock6.rs
+++ b/tests/fail/sock6.rs
@@ -1,4 +1,4 @@
-use net_macros::sock6;
+use const_addrs::sock6;
 
 fn main() {
     let a = sock6!("2001:db8::32::23:22");

--- a/tests/pass/ip.rs
+++ b/tests/pass/ip.rs
@@ -1,4 +1,4 @@
-use net_macros::ip;
+use const_addrs::ip;
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 

--- a/tests/pass/ip4.rs
+++ b/tests/pass/ip4.rs
@@ -1,6 +1,6 @@
 use std::net::Ipv4Addr;
 
-use net_macros::ip4;
+use const_addrs::ip4;
 
 fn main() {
     let a = ip4!("192.168.1.1");

--- a/tests/pass/ip6.rs
+++ b/tests/pass/ip6.rs
@@ -1,4 +1,4 @@
-use net_macros::ip6;
+use const_addrs::ip6;
 use std::net::Ipv6Addr;
 
 fn main() {

--- a/tests/pass/mac.rs
+++ b/tests/pass/mac.rs
@@ -1,6 +1,6 @@
 use macaddr::{MacAddr, MacAddr6, MacAddr8};
 
-use net_macros::mac;
+use const_addrs::mac;
 
 fn main() {
     let a = mac!("c0:ff:ee:c0:ff:ee");

--- a/tests/pass/mac6.rs
+++ b/tests/pass/mac6.rs
@@ -1,6 +1,6 @@
 use macaddr::MacAddr6;
 
-use net_macros::mac6;
+use const_addrs::mac6;
 
 fn main() {
     let a = mac6!("c0:ff:ee:c0:ff:ee");

--- a/tests/pass/mac8.rs
+++ b/tests/pass/mac8.rs
@@ -1,6 +1,6 @@
 use macaddr::MacAddr8;
 
-use net_macros::mac8;
+use const_addrs::mac8;
 
 fn main() {
     let a = mac8!("c0:ff:ee:c0:ff:ee:ca:fe");

--- a/tests/pass/net.rs
+++ b/tests/pass/net.rs
@@ -1,6 +1,6 @@
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 
-use net_macros::{ip4, ip6, net};
+use const_addrs::{ip4, ip6, net};
 
 fn main() {
     let a = net!("192.168.1.1/24");

--- a/tests/pass/net4.rs
+++ b/tests/pass/net4.rs
@@ -1,6 +1,6 @@
 use ipnetwork::Ipv4Network;
 
-use net_macros::{ip4, net4};
+use const_addrs::{ip4, net4};
 
 fn main() {
     let a = net4!("192.168.1.1/24");

--- a/tests/pass/net6.rs
+++ b/tests/pass/net6.rs
@@ -1,6 +1,6 @@
 use ipnetwork::Ipv6Network;
 
-use net_macros::{ip6, net6};
+use const_addrs::{ip6, net6};
 
 fn main() {
     let a = net6!("2001:db8::32:23/63");

--- a/tests/pass/sock.rs
+++ b/tests/pass/sock.rs
@@ -1,6 +1,6 @@
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 
-use net_macros::{ip4, ip6, sock};
+use const_addrs::{ip4, ip6, sock};
 
 fn main() {
     let a = sock!("192.168.1.1:300");

--- a/tests/pass/sock4.rs
+++ b/tests/pass/sock4.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddrV4;
 
-use net_macros::{ip4, sock4};
+use const_addrs::{ip4, sock4};
 
 fn main() {
     let a = sock4!("192.168.1.1:300");

--- a/tests/pass/sock6.rs
+++ b/tests/pass/sock6.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddrV6;
 
-use net_macros::{ip6, sock6};
+use const_addrs::{ip6, sock6};
 
 fn main() {
     let a = sock6!("[2001:db8::32:23]:22");


### PR DESCRIPTION
I think the old name: net-macros suggests its somehow part of the std::net package which of course isn't true.