### PR TITLE
Opt out of default features (serde) for ipnetwork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mac = ["dep:macaddr"]
 [dependencies]
 cfg-if = "1"
 document-features = { version = "0.2", optional = true }
-ipnetwork = { version = "0.20.0", optional = true }
+ipnetwork = { version = "0.20.0", optional = true, default-features = false }
 macaddr = { version = "1.0", optional = true }
 proc-macro-error = "1.0"
 proc-macro2 = "1"
@@ -34,7 +34,7 @@ syn = "2.0"
 
 [dev-dependencies]
 trybuild = "1"
-ipnetwork = "0.20.0"
+ipnetwork = { version = "0.20.0", default-features = false }
 macaddr = "1.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Thank you for a really nice crate! Being able to create const/static IP types that are properly checked at compile time has been something I have wanted for a long time. This crate solves part of that problem very elegantly :sparkles: 

When depending on `const-addrs` and enabling the `ipnet` feature, I also get `serde` as a transitive dependency. None of the code in my dependency tree uses `serde` for anything. This is just the unfortunate situation we are in with default features in Cargo. I regard them as an antipattern more than anything else.

This PR opts out of any default features in `ipnetwork`. Currently that's simply the `serde` functionality being removed.

I have submitted a PR towards `ipnetwork` to remove `serde` as a default feature also. So this might be solved in a future release. We can't know yet: https://github.com/achanda/ipnetwork/pull/200