### PR TITLE
ipnetwork const constructors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mac = ["dep:macaddr"]
 [dependencies]
 cfg-if = "1"
 document-features = { version = "0.2", optional = true }
-ipnetwork = { version = "0.20.0", optional = true, default-features = false }
+ipnetwork = { version = "0.21.1", optional = true, default-features = false }
 macaddr = { version = "1.0", optional = true }
 proc-macro-error = "1.0"
 proc-macro2 = "1"
@@ -34,7 +34,7 @@ syn = "2.0"
 
 [dev-dependencies]
 trybuild = "1"
-ipnetwork = { version = "0.20.0", default-features = false }
+ipnetwork = { version = "0.21.1", default-features = false }
 macaddr = "1.0"
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ cfg_if::cfg_if! {
             net4_tokens => |net| {
                 let ip = ip4_tokens(net.ip());
                 let prefix = net.prefix();
-                quote! { ipnetwork::Ipv4Network::new(#ip, #prefix).unwrap() }
+                quote! { ipnetwork::Ipv4Network::new_checked(#ip, #prefix).unwrap() }
             };
             "ipnet"
         }
@@ -243,7 +243,7 @@ cfg_if::cfg_if! {
             net6_tokens => |net| {
                 let ip = ip6_tokens(net.ip());
                 let prefix = net.prefix();
-                quote! { ipnetwork::Ipv6Network::new(#ip, #prefix).unwrap() }
+                quote! { ipnetwork::Ipv6Network::new_checked(#ip, #prefix).unwrap() }
             };
             "ipnet"
         }

--- a/tests/fail/ip.rs
+++ b/tests/fail/ip.rs
@@ -1,6 +1,6 @@
 use const_addrs::ip;
 
 fn main() {
-    let a = ip!("192.168.11");
-    let b = ip!("2001:db8::32::23");
+    let _ = ip!("192.168.11");
+    let _ = ip!("2001:db8::32::23");
 }

--- a/tests/fail/ip.stderr
+++ b/tests/fail/ip.stderr
@@ -1,11 +1,11 @@
 error: invalid IP address syntax
  --> tests/fail/ip.rs:4:17
   |
-4 |     let a = ip!("192.168.11");
+4 |     let _ = ip!("192.168.11");
   |                 ^^^^^^^^^^^^
 
 error: invalid IP address syntax
  --> tests/fail/ip.rs:5:17
   |
-5 |     let b = ip!("2001:db8::32::23");
+5 |     let _ = ip!("2001:db8::32::23");
   |                 ^^^^^^^^^^^^^^^^^^

--- a/tests/fail/ip4.rs
+++ b/tests/fail/ip4.rs
@@ -1,5 +1,5 @@
 use const_addrs::ip4;
 
 fn main() {
-    let a = ip4!("192.168.11");
+    let _ = ip4!("192.168.11");
 }

--- a/tests/fail/ip4.stderr
+++ b/tests/fail/ip4.stderr
@@ -1,5 +1,5 @@
 error: invalid IPv4 address syntax
  --> tests/fail/ip4.rs:4:18
   |
-4 |     let a = ip4!("192.168.11");
+4 |     let _ = ip4!("192.168.11");
   |                  ^^^^^^^^^^^^

--- a/tests/fail/ip6.rs
+++ b/tests/fail/ip6.rs
@@ -1,5 +1,5 @@
 use const_addrs::ip6;
 
 fn main() {
-    let a = ip6!("2001:db8::32::23");
+    let _ = ip6!("2001:db8::32::23");
 }

--- a/tests/fail/ip6.stderr
+++ b/tests/fail/ip6.stderr
@@ -1,5 +1,5 @@
 error: invalid IPv6 address syntax
  --> tests/fail/ip6.rs:4:18
   |
-4 |     let a = ip6!("2001:db8::32::23");
+4 |     let _ = ip6!("2001:db8::32::23");
   |                  ^^^^^^^^^^^^^^^^^^

--- a/tests/fail/mac.rs
+++ b/tests/fail/mac.rs
@@ -1,6 +1,6 @@
 use const_addrs::mac;
 
 fn main() {
-    let a = mac!("ca:fe:ca:fe");
-    let b = mac!("ca:fe:ca:fe:ca:fe:cafe");
+    let _ = mac!("ca:fe:ca:fe");
+    let _ = mac!("ca:fe:ca:fe:ca:fe:cafe");
 }

--- a/tests/fail/mac.stderr
+++ b/tests/fail/mac.stderr
@@ -1,5 +1,5 @@
 error: Invalid length of 11 characters
  --> tests/fail/mac.rs:4:18
   |
-4 |     let a = mac!("ca:fe:ca:fe");
+4 |     let _ = mac!("ca:fe:ca:fe");
   |                  ^^^^^^^^^^^^^

--- a/tests/fail/mac6.rs
+++ b/tests/fail/mac6.rs
@@ -1,5 +1,5 @@
 use const_addrs::mac6;
 
 fn main() {
-    let a = mac6!("ca:fe:ca:fe:c0:ff:ee");
+    let _ = mac6!("ca:fe:ca:fe:c0:ff:ee");
 }

--- a/tests/fail/mac6.stderr
+++ b/tests/fail/mac6.stderr
@@ -1,5 +1,5 @@
 error: Invalid length of 20 characters
  --> tests/fail/mac6.rs:4:19
   |
-4 |     let a = mac6!("ca:fe:ca:fe:c0:ff:ee");
+4 |     let _ = mac6!("ca:fe:ca:fe:c0:ff:ee");
   |                   ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/fail/mac8.rs
+++ b/tests/fail/mac8.rs
@@ -1,5 +1,5 @@
 use const_addrs::mac8;
 
 fn main() {
-    let a = mac8!("ca:fe:ca:fe:ca:fe");
+    let _ = mac8!("ca:fe:ca:fe:ca:fe");
 }

--- a/tests/fail/mac8.stderr
+++ b/tests/fail/mac8.stderr
@@ -1,5 +1,5 @@
 error: Invalid length of 17 characters
  --> tests/fail/mac8.rs:4:19
   |
-4 |     let a = mac8!("ca:fe:ca:fe:ca:fe");
+4 |     let _ = mac8!("ca:fe:ca:fe:ca:fe");
   |                   ^^^^^^^^^^^^^^^^^^^

--- a/tests/fail/net.rs
+++ b/tests/fail/net.rs
@@ -1,6 +1,6 @@
 use const_addrs::net;
 
 fn main() {
-    let a = net!("192.168.1.1/300");
-    let b = net!("2001:db8::32::23/129");
+    let _ = net!("192.168.1.1/300");
+    let _ = net!("2001:db8::32::23/129");
 }

--- a/tests/fail/net.stderr
+++ b/tests/fail/net.stderr
@@ -1,11 +1,11 @@
 error: invalid address: 192.168.1.1/300
  --> tests/fail/net.rs:4:18
   |
-4 |     let a = net!("192.168.1.1/300");
+4 |     let _ = net!("192.168.1.1/300");
   |                  ^^^^^^^^^^^^^^^^^
 
 error: invalid address: 2001:db8::32::23/129
  --> tests/fail/net.rs:5:18
   |
-5 |     let b = net!("2001:db8::32::23/129");
+5 |     let _ = net!("2001:db8::32::23/129");
   |                  ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/fail/net4.rs
+++ b/tests/fail/net4.rs
@@ -1,5 +1,5 @@
 use const_addrs::net4;
 
 fn main() {
-    let a = net4!("192.168.1.1/300");
+    let _ = net4!("192.168.1.1/300");
 }

--- a/tests/fail/net4.stderr
+++ b/tests/fail/net4.stderr
@@ -1,5 +1,5 @@
 error: invalid prefix
  --> tests/fail/net4.rs:4:19
   |
-4 |     let a = net4!("192.168.1.1/300");
+4 |     let _ = net4!("192.168.1.1/300");
   |                   ^^^^^^^^^^^^^^^^^

--- a/tests/fail/net6.rs
+++ b/tests/fail/net6.rs
@@ -1,5 +1,6 @@
 use const_addrs::net6;
 
 fn main() {
-    let a = net6!("2001:db8::32::23/129");
+    let _ = net6!("2001:db8::32::23/129");
+    let _ = net6!("2001:db8::32:23/129");
 }

--- a/tests/fail/net6.stderr
+++ b/tests/fail/net6.stderr
@@ -1,5 +1,11 @@
-error: invalid address: 2001:db8::32::23
+error: invalid address: invalid IPv6 address syntax
  --> tests/fail/net6.rs:4:19
   |
-4 |     let a = net6!("2001:db8::32::23/129");
+4 |     let _ = net6!("2001:db8::32::23/129");
   |                   ^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid prefix
+ --> tests/fail/net6.rs:5:19
+  |
+5 |     let _ = net6!("2001:db8::32:23/129");
+  |                   ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/fail/sock.rs
+++ b/tests/fail/sock.rs
@@ -1,6 +1,6 @@
 use const_addrs::sock;
 
 fn main() {
-    let a = sock!("192.168.11:300");
-    let b = sock!("2001:db8::32::23:22");
+    let _ = sock!("192.168.11:300");
+    let _ = sock!("2001:db8::32::23:22");
 }

--- a/tests/fail/sock.stderr
+++ b/tests/fail/sock.stderr
@@ -1,11 +1,11 @@
 error: invalid socket address syntax
  --> tests/fail/sock.rs:4:19
   |
-4 |     let a = sock!("192.168.11:300");
+4 |     let _ = sock!("192.168.11:300");
   |                   ^^^^^^^^^^^^^^^^
 
 error: invalid socket address syntax
  --> tests/fail/sock.rs:5:19
   |
-5 |     let b = sock!("2001:db8::32::23:22");
+5 |     let _ = sock!("2001:db8::32::23:22");
   |                   ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/fail/sock4.rs
+++ b/tests/fail/sock4.rs
@@ -1,5 +1,5 @@
 use const_addrs::sock4;
 
 fn main() {
-    let a = sock4!("192.168.11:300");
+    let _ = sock4!("192.168.11:300");
 }

--- a/tests/fail/sock4.stderr
+++ b/tests/fail/sock4.stderr
@@ -1,5 +1,5 @@
 error: invalid IPv4 socket address syntax
  --> tests/fail/sock4.rs:4:20
   |
-4 |     let a = sock4!("192.168.11:300");
+4 |     let _ = sock4!("192.168.11:300");
   |                    ^^^^^^^^^^^^^^^^

--- a/tests/fail/sock6.rs
+++ b/tests/fail/sock6.rs
@@ -1,5 +1,5 @@
 use const_addrs::sock6;
 
 fn main() {
-    let a = sock6!("2001:db8::32::23:22");
+    let _ = sock6!("2001:db8::32::23:22");
 }

--- a/tests/fail/sock6.stderr
+++ b/tests/fail/sock6.stderr
@@ -1,5 +1,5 @@
 error: invalid IPv6 socket address syntax
  --> tests/fail/sock6.rs:4:20
   |
-4 |     let a = sock6!("2001:db8::32::23:22");
+4 |     let _ = sock6!("2001:db8::32::23:22");
   |                    ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Update ipnetwork dependecy to version 0.21.1 and take advantage of the const constructors for its types. This also updates tests for the latest output.

fixes: #5 