### PR TITLE
release: release 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-addrs"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Erich Heine"]


### PR DESCRIPTION
This is the same as release 0.1.2 but properly semver for the breaking change caused by updating the dependency