### PR TITLE
Bump lower bound on trybuild dependency to fix compilation error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ quote = "1.0"
 syn = "2.0"
 
 [dev-dependencies]
-trybuild = "1"
+trybuild = "1.0.104"
 ipnetwork = { version = "0.21.1", default-features = false }
 macaddr = "1.0"
 


### PR DESCRIPTION
This library could not build with trybuild 1.0.0, so the lower bound on the dependency was wrong.

This cherry-picks the corresponding commit from #14 since you thought that PR would be stalled for a while. Also this PR does not add the lockfile, since that's not needed to fix this lower bound dependency bug.

To test this change out, try running the following against this library:
```
$ cargo +nightly update -Z minimal-versions
$ cargo +stable build --all-targets --locked
```
And you will notice you get lots and lots of compilation errors. And then you run it against this branch and see that they go away. Somewhere between `1.0.0` and `1.0.104` the `trybuild` dependency fixed their lower bound issue. I did not think it was important to figure out a more strict lower bound. Just raising it to the latest release is IMHO fine.