### PR TITLE
Issue #21 additional ipnet types

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta]
+        rust: [stable, beta, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +31,14 @@ jobs:
 
       # Run through all tests with all combinations of features
       - name: Test
+        if: ${{ matrix.rust == 'stable' || matrix.rust == 'beta' }}
+        run: cargo hack --feature-powerset --exclude-all-features test
+
+      # Run through all tests with all combinations of features
+      - name: Test Nightly
+        if: ${{ matrix.rust == 'nightly' }}
+        env:
+          RUSTFLAGS: "--cfg=nightly"
         run: cargo hack --feature-powerset --exclude-all-features test
 
       # Make sure documentation builds without warnings (broken links etc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Initial support for `ipnet` network types
+- Support for `ipnet` network types: IpNet, IpAddrRange, IpSubnets (and their v4 and v6
+  specific equivalents)
 
 ### Changed
 - Rename the "ipnet" feature to "ipnetwork" to match the dependency.

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ serv:
 .PHONY: test
 test:
 	cargo test --all-features
-	cargo +nightly test --all-features 
+	RUSTFLAGS="--cfg=nightly" cargo +nightly test --all-features 

--- a/README.md
+++ b/README.md
@@ -28,23 +28,27 @@ error: invalid IPv4 address syntax
 
 There are macros for:
 
-| Type                     | macro      |
-| ------------------------ | ---------- |
-| `std::net::IpAddr`       | `ip!`      |
-| `std::net::Ipv4Addr`     | `ip4!`     |
-| `std::net::Ipv6Addr`     | `ip6!`     |
-| `std::net::SocketAddr`   | `sock!`    |
-| `std::net::SocketAddrV4` | `sock4!`   |
-| `std::net::SocketAddrV6` | `sock6!`   |
-| `ipnet::IpNet`           | `ipnet!`   |
-| `ipnet::Ipv4Net`         | `ipnet4!`  |
-| `ipnet::Ipv6Net`         | `ipnet6!`  |
-| `ipnetwork::IpNetwork`   | `net!`     |
-| `ipnetwork::Ipv4Network` | `net4!`    |
-| `ipnetwork::Ipv6Network` | `net6!`    |
-| `macaddr::MacAddr`       | `mac!`     |
-| `macaddr::MacAddr6`      | `mac6!`    |
-| `macaddr::MacAddr8`      | `mac8!`    |
+| Type                     | macro         |
+| ------------------------ | ----------    |
+| `std::net::IpAddr`       | `ip!`         |
+| `std::net::Ipv4Addr`     | `ip4!`        |
+| `std::net::Ipv6Addr`     | `ip6!`        |
+| `std::net::SocketAddr`   | `sock!`       |
+| `std::net::SocketAddrV4` | `sock4!`      |
+| `std::net::SocketAddrV6` | `sock6!`      |
+| `ipnet::IpNet`           | `ipnet!`      |
+| `ipnet::IpAddrRange`     | `iprange!`    |
+| `ipnet::Ipv4AddrRange`   | `iprange4!`   |
+| `ipnet::Ipv6AddrRange`   | `iprange6!`   |
+| `ipnet::IpSubnets`       | `ipsubnets!`  |
+| `ipnet::Ipv4Subnets`     | `ipsubnets4!` |
+| `ipnet::Ipv6Subnets`     | `ipsubnets6!` |
+| `ipnetwork::IpNetwork`   | `net!`        |
+| `ipnetwork::Ipv4Network` | `net4!`       |
+| `ipnetwork::Ipv6Network` | `net6!`       |
+| `macaddr::MacAddr`       | `mac!`        |
+| `macaddr::MacAddr6`      | `mac6!`       |
+| `macaddr::MacAddr8`      | `mac8!`       |
 
 
 *Note*: using `ipnet::*` types requires you to have the 

--- a/tests/fail/iprange.rs
+++ b/tests/fail/iprange.rs
@@ -1,0 +1,12 @@
+use const_addrs::iprange;
+
+fn main() {
+    let _ = iprange!("2001:db8::32:23", "2001:db8::32::ffff");
+    let _ = iprange!("2001:db8::32::23", "2001:db8::32:ffff");
+    let _ = iprange!("2001:db8::32::23", "2001:db8::32::ffff");
+    let _ = iprange!("2001:db8::32:23", "10.0.0.2");
+    let _ = iprange!("10.0.0.1", "2001:db8::32:23");
+    let _ = iprange!("2001:db8::32:23", "10.0.0.1");
+    let _ = iprange!("100.0.0", "10.0.0.255");
+    let _ = iprange!("10.0.0.0", "10.0.0255");
+}

--- a/tests/fail/iprange.stderr
+++ b/tests/fail/iprange.stderr
@@ -1,0 +1,55 @@
+error: invalid IP address syntax
+ --> tests/fail/iprange.rs:4:41
+  |
+4 |     let _ = iprange!("2001:db8::32:23", "2001:db8::32::ffff");
+  |                                         ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail/iprange.rs:5:22
+  |
+5 |     let _ = iprange!("2001:db8::32::23", "2001:db8::32:ffff");
+  |                      ^^^^^^^^^^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+ --> tests/fail/iprange.rs:6:42
+  |
+6 |     let _ = iprange!("2001:db8::32::23", "2001:db8::32::ffff");
+  |             -----------------------------^^^^^^^^^^^^^^^^^^^^- caused by the macro expansion here
+  |
+  = note: the usage of `iprange!` is likely invalid in expression context
+
+error: invalid IP address syntax
+ --> tests/fail/iprange.rs:6:22
+  |
+6 |     let _ = iprange!("2001:db8::32::23", "2001:db8::32::ffff");
+  |                      ^^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail/iprange.rs:7:41
+  |
+7 |     let _ = iprange!("2001:db8::32:23", "10.0.0.2");
+  |                                         ^^^^^^^^^^
+
+error: Addr is IPv6 but IPv4 is expected
+ --> tests/fail/iprange.rs:8:34
+  |
+8 |     let _ = iprange!("10.0.0.1", "2001:db8::32:23");
+  |                                  ^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail/iprange.rs:9:41
+  |
+9 |     let _ = iprange!("2001:db8::32:23", "10.0.0.1");
+  |                                         ^^^^^^^^^^
+
+error: invalid IP address syntax
+  --> tests/fail/iprange.rs:10:22
+   |
+10 |     let _ = iprange!("100.0.0", "10.0.0.255");
+   |                      ^^^^^^^^^
+
+error: invalid IP address syntax
+  --> tests/fail/iprange.rs:11:34
+   |
+11 |     let _ = iprange!("10.0.0.0", "10.0.0255");
+   |                                  ^^^^^^^^^^^

--- a/tests/fail/iprange4.rs
+++ b/tests/fail/iprange4.rs
@@ -1,0 +1,8 @@
+use const_addrs::iprange4;
+
+fn main() {
+    let _ = iprange4!("10.0.01", "10.0.1.0");
+    let _ = iprange4!("10.0.0.1", "10.0.10");
+    let _ = iprange4!("10.0.01", "10.0.10");
+    let _ = iprange4!("10.0.0.1", "2001:db8::32:23");
+}

--- a/tests/fail/iprange4.stderr
+++ b/tests/fail/iprange4.stderr
@@ -1,0 +1,31 @@
+error: invalid IP address syntax
+ --> tests/fail/iprange4.rs:4:23
+  |
+4 |     let _ = iprange4!("10.0.01", "10.0.1.0");
+  |                       ^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail/iprange4.rs:5:35
+  |
+5 |     let _ = iprange4!("10.0.0.1", "10.0.10");
+  |                                   ^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+ --> tests/fail/iprange4.rs:6:34
+  |
+6 |     let _ = iprange4!("10.0.01", "10.0.10");
+  |             ---------------------^^^^^^^^^- caused by the macro expansion here
+  |
+  = note: the usage of `iprange4!` is likely invalid in expression context
+
+error: invalid IP address syntax
+ --> tests/fail/iprange4.rs:6:23
+  |
+6 |     let _ = iprange4!("10.0.01", "10.0.10");
+  |                       ^^^^^^^^^
+
+error: Addr is IPv6 but IPv4 is expected
+ --> tests/fail/iprange4.rs:7:35
+  |
+7 |     let _ = iprange4!("10.0.0.1", "2001:db8::32:23");
+  |                                   ^^^^^^^^^^^^^^^^^

--- a/tests/fail/iprange6.rs
+++ b/tests/fail/iprange6.rs
@@ -1,0 +1,9 @@
+use const_addrs::iprange6;
+
+fn main() {
+    let _ = iprange6!("2001:db8::32:23", "2001:db8::32::ffff");
+    let _ = iprange6!("2001:db8::32::23", "2001:db8::32:ffff");
+    let _ = iprange6!("2001:db8::32::23", "2001:db8::32::ffff");
+    let _ = iprange6!("2001:db8::32:23", "10.0.0.2");
+    let _ = iprange6!("10.0.0.1", "2001:db8::32:23");
+}

--- a/tests/fail/iprange6.stderr
+++ b/tests/fail/iprange6.stderr
@@ -1,0 +1,37 @@
+error: invalid IP address syntax
+ --> tests/fail/iprange6.rs:4:42
+  |
+4 |     let _ = iprange6!("2001:db8::32:23", "2001:db8::32::ffff");
+  |                                          ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail/iprange6.rs:5:23
+  |
+5 |     let _ = iprange6!("2001:db8::32::23", "2001:db8::32:ffff");
+  |                       ^^^^^^^^^^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+ --> tests/fail/iprange6.rs:6:43
+  |
+6 |     let _ = iprange6!("2001:db8::32::23", "2001:db8::32::ffff");
+  |             ------------------------------^^^^^^^^^^^^^^^^^^^^- caused by the macro expansion here
+  |
+  = note: the usage of `iprange6!` is likely invalid in expression context
+
+error: invalid IP address syntax
+ --> tests/fail/iprange6.rs:6:23
+  |
+6 |     let _ = iprange6!("2001:db8::32::23", "2001:db8::32::ffff");
+  |                       ^^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail/iprange6.rs:7:42
+  |
+7 |     let _ = iprange6!("2001:db8::32:23", "10.0.0.2");
+  |                                          ^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail/iprange6.rs:8:23
+  |
+8 |     let _ = iprange6!("10.0.0.1", "2001:db8::32:23");
+  |                       ^^^^^^^^^^

--- a/tests/fail/ipsubnets.rs
+++ b/tests/fail/ipsubnets.rs
@@ -1,0 +1,17 @@
+use const_addrs::ipsubnets;
+
+fn main() {
+    let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32::ffff", 48);
+    let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32:ffff", 48);
+    let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32::ffff", 48);
+    let _ = ipsubnets!("2001:db8::32:23", "10.0.0.2", 48);
+    let _ = ipsubnets!("10.0.0.1", "2001:db8::32:23", 48);
+    let _ = ipsubnets!("2001:db8::32:23", "10.0.0.1", 48);
+    let _ = ipsubnets!("100.0.0", "10.0.0.255", 48);
+    let _ = ipsubnets!("10.0.0.0", "10.0.0255", 24);
+    let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32:ffff", 129);
+    let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32:ffff", 260);
+
+    let _ = ipsubnets!("10.0.0.1", "10.0.10.1", 33);
+    let _ = ipsubnets!("10.0.0.1", "10.0.10.1", 260);
+}

--- a/tests/fail/ipsubnets.stderr
+++ b/tests/fail/ipsubnets.stderr
@@ -1,0 +1,103 @@
+error: invalid IP address syntax
+ --> tests/fail/ipsubnets.rs:4:43
+  |
+4 |     let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32::ffff", 48);
+  |                                           ^^^^^^^^^^^^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+ --> tests/fail/ipsubnets.rs:5:65
+  |
+5 |     let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32:ffff", 48);
+  |             ----------------------------------------------------^^- caused by the macro expansion here
+  |
+  = note: the usage of `ipsubnets!` is likely invalid in expression context
+
+error: invalid IP address syntax
+ --> tests/fail/ipsubnets.rs:5:24
+  |
+5 |     let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32:ffff", 48);
+  |                        ^^^^^^^^^^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+ --> tests/fail/ipsubnets.rs:6:44
+  |
+6 |     let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32::ffff", 48);
+  |             -------------------------------^^^^^^^^^^^^^^^^^^^^----- caused by the macro expansion here
+  |
+  = note: the usage of `ipsubnets!` is likely invalid in expression context
+
+error: invalid IP address syntax
+ --> tests/fail/ipsubnets.rs:6:24
+  |
+6 |     let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32::ffff", 48);
+  |                        ^^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail/ipsubnets.rs:7:43
+  |
+7 |     let _ = ipsubnets!("2001:db8::32:23", "10.0.0.2", 48);
+  |                                           ^^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+ --> tests/fail/ipsubnets.rs:8:55
+  |
+8 |     let _ = ipsubnets!("10.0.0.1", "2001:db8::32:23", 48);
+  |             ------------------------------------------^^- caused by the macro expansion here
+  |
+  = note: the usage of `ipsubnets!` is likely invalid in expression context
+
+error: Addr is IPv6 but IPv4 is expected
+ --> tests/fail/ipsubnets.rs:8:36
+  |
+8 |     let _ = ipsubnets!("10.0.0.1", "2001:db8::32:23", 48);
+  |                                    ^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail/ipsubnets.rs:9:43
+  |
+9 |     let _ = ipsubnets!("2001:db8::32:23", "10.0.0.1", 48);
+  |                                           ^^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+  --> tests/fail/ipsubnets.rs:10:49
+   |
+10 |     let _ = ipsubnets!("100.0.0", "10.0.0.255", 48);
+   |             ------------------------------------^^- caused by the macro expansion here
+   |
+   = note: the usage of `ipsubnets!` is likely invalid in expression context
+
+error: invalid IP address syntax
+  --> tests/fail/ipsubnets.rs:10:24
+   |
+10 |     let _ = ipsubnets!("100.0.0", "10.0.0.255", 48);
+   |                        ^^^^^^^^^
+
+error: invalid IP address syntax
+  --> tests/fail/ipsubnets.rs:11:36
+   |
+11 |     let _ = ipsubnets!("10.0.0.0", "10.0.0255", 24);
+   |                                    ^^^^^^^^^^^
+
+error: Minimum prefix must be 128 or less
+  --> tests/fail/ipsubnets.rs:12:64
+   |
+12 |     let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32:ffff", 129);
+   |                                                                ^^^
+
+error: number too large to fit in target type
+  --> tests/fail/ipsubnets.rs:13:64
+   |
+13 |     let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32:ffff", 260);
+   |                                                                ^^^
+
+error: Minimum prefix must be 32 or less
+  --> tests/fail/ipsubnets.rs:15:49
+   |
+15 |     let _ = ipsubnets!("10.0.0.1", "10.0.10.1", 33);
+   |                                                 ^^
+
+error: number too large to fit in target type
+  --> tests/fail/ipsubnets.rs:16:49
+   |
+16 |     let _ = ipsubnets!("10.0.0.1", "10.0.10.1", 260);
+   |                                                 ^^^

--- a/tests/fail/ipsubnets4.rs
+++ b/tests/fail/ipsubnets4.rs
@@ -1,0 +1,10 @@
+use const_addrs::ipsubnets4;
+
+fn main() {
+    let _ = ipsubnets4!("10.0.01", "10.0.1.0", 24);
+    let _ = ipsubnets4!("10.0.0.1", "10.0.10", 24);
+    let _ = ipsubnets4!("10.0.01", "10.0.10", 24);
+    let _ = ipsubnets4!("10.0.0.1", "2001:db8::32:23", 24);
+    let _ = ipsubnets4!("10.0.0.1", "10.0.10.0", 33);
+    let _ = ipsubnets4!("10.0.0.1", "10.0.10.0", 260);
+}

--- a/tests/fail/ipsubnets4.stderr
+++ b/tests/fail/ipsubnets4.stderr
@@ -1,0 +1,43 @@
+error: invalid IP address syntax
+ --> tests/fail/ipsubnets4.rs:4:25
+  |
+4 |     let _ = ipsubnets4!("10.0.01", "10.0.1.0", 24);
+  |                         ^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail/ipsubnets4.rs:5:37
+  |
+5 |     let _ = ipsubnets4!("10.0.0.1", "10.0.10", 24);
+  |                                     ^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+ --> tests/fail/ipsubnets4.rs:6:36
+  |
+6 |     let _ = ipsubnets4!("10.0.01", "10.0.10", 24);
+  |             -----------------------^^^^^^^^^----- caused by the macro expansion here
+  |
+  = note: the usage of `ipsubnets4!` is likely invalid in expression context
+
+error: invalid IP address syntax
+ --> tests/fail/ipsubnets4.rs:6:25
+  |
+6 |     let _ = ipsubnets4!("10.0.01", "10.0.10", 24);
+  |                         ^^^^^^^^^
+
+error: Addr is IPv6 but IPv4 is expected
+ --> tests/fail/ipsubnets4.rs:7:37
+  |
+7 |     let _ = ipsubnets4!("10.0.0.1", "2001:db8::32:23", 24);
+  |                                     ^^^^^^^^^^^^^^^^^
+
+error: Minimum prefix must be 32 or less
+ --> tests/fail/ipsubnets4.rs:8:50
+  |
+8 |     let _ = ipsubnets4!("10.0.0.1", "10.0.10.0", 33);
+  |                                                  ^^
+
+error: number too large to fit in target type
+ --> tests/fail/ipsubnets4.rs:9:50
+  |
+9 |     let _ = ipsubnets4!("10.0.0.1", "10.0.10.0", 260);
+  |                                                  ^^^

--- a/tests/fail/ipsubnets6.rs
+++ b/tests/fail/ipsubnets6.rs
@@ -1,0 +1,11 @@
+use const_addrs::ipsubnets6;
+
+fn main() {
+    let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32:ffff", 24);
+    let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32::ffff", 24);
+    let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32::ffff", 24);
+    let _ = ipsubnets6!("2001:db8::32:23", "10.0.0.1", 24);
+    let _ = ipsubnets6!("10.0.0.1", "2001:db8::32:ffff", 129);
+    let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32:ffff", 129);
+    let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32:ffff", 260);
+}

--- a/tests/fail/ipsubnets6.stderr
+++ b/tests/fail/ipsubnets6.stderr
@@ -1,0 +1,57 @@
+error: invalid IP address syntax
+ --> tests/fail/ipsubnets6.rs:4:25
+  |
+4 |     let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32:ffff", 24);
+  |                         ^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail/ipsubnets6.rs:5:44
+  |
+5 |     let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32::ffff", 24);
+  |                                            ^^^^^^^^^^^^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+ --> tests/fail/ipsubnets6.rs:6:45
+  |
+6 |     let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32::ffff", 24);
+  |             --------------------------------^^^^^^^^^^^^^^^^^^^^----- caused by the macro expansion here
+  |
+  = note: the usage of `ipsubnets6!` is likely invalid in expression context
+
+error: invalid IP address syntax
+ --> tests/fail/ipsubnets6.rs:6:25
+  |
+6 |     let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32::ffff", 24);
+  |                         ^^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail/ipsubnets6.rs:7:44
+  |
+7 |     let _ = ipsubnets6!("2001:db8::32:23", "10.0.0.1", 24);
+  |                                            ^^^^^^^^^^
+
+error: macro expansion ignores `compile_error` and any tokens following
+ --> tests/fail/ipsubnets6.rs:8:58
+  |
+8 |     let _ = ipsubnets6!("10.0.0.1", "2001:db8::32:ffff", 129);
+  |             ---------------------------------------------^^^- caused by the macro expansion here
+  |
+  = note: the usage of `ipsubnets6!` is likely invalid in expression context
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail/ipsubnets6.rs:8:25
+  |
+8 |     let _ = ipsubnets6!("10.0.0.1", "2001:db8::32:ffff", 129);
+  |                         ^^^^^^^^^^
+
+error: Minimum prefix must be 128 or less
+ --> tests/fail/ipsubnets6.rs:9:65
+  |
+9 |     let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32:ffff", 129);
+  |                                                                 ^^^
+
+error: number too large to fit in target type
+  --> tests/fail/ipsubnets6.rs:10:65
+   |
+10 |     let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32:ffff", 260);
+   |                                                                 ^^^

--- a/tests/fail_nightly/iprange.rs
+++ b/tests/fail_nightly/iprange.rs
@@ -1,0 +1,12 @@
+use const_addrs::iprange;
+
+fn main() {
+    let _ = iprange!("2001:db8::32:23", "2001:db8::32::ffff");
+    let _ = iprange!("2001:db8::32::23", "2001:db8::32:ffff");
+    let _ = iprange!("2001:db8::32::23", "2001:db8::32::ffff");
+    let _ = iprange!("2001:db8::32:23", "10.0.0.2");
+    let _ = iprange!("10.0.0.1", "2001:db8::32:23");
+    let _ = iprange!("2001:db8::32:23", "10.0.0.1");
+    let _ = iprange!("100.0.0", "10.0.0.255");
+    let _ = iprange!("10.0.0.0", "10.0.0255");
+}

--- a/tests/fail_nightly/iprange.stderr
+++ b/tests/fail_nightly/iprange.stderr
@@ -1,0 +1,53 @@
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange.rs:4:41
+  |
+4 |     let _ = iprange!("2001:db8::32:23", "2001:db8::32::ffff");
+  |                                         ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange.rs:5:22
+  |
+5 |     let _ = iprange!("2001:db8::32::23", "2001:db8::32:ffff");
+  |                      ^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange.rs:6:22
+  |
+6 |     let _ = iprange!("2001:db8::32::23", "2001:db8::32::ffff");
+  |                      ^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange.rs:6:42
+  |
+6 |     let _ = iprange!("2001:db8::32::23", "2001:db8::32::ffff");
+  |                                          ^^^^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail_nightly/iprange.rs:7:41
+  |
+7 |     let _ = iprange!("2001:db8::32:23", "10.0.0.2");
+  |                                         ^^^^^^^^^^
+
+error: Addr is IPv6 but IPv4 is expected
+ --> tests/fail_nightly/iprange.rs:8:34
+  |
+8 |     let _ = iprange!("10.0.0.1", "2001:db8::32:23");
+  |                                  ^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail_nightly/iprange.rs:9:41
+  |
+9 |     let _ = iprange!("2001:db8::32:23", "10.0.0.1");
+  |                                         ^^^^^^^^^^
+
+error: invalid IP address syntax
+  --> tests/fail_nightly/iprange.rs:10:22
+   |
+10 |     let _ = iprange!("100.0.0", "10.0.0.255");
+   |                      ^^^^^^^^^
+
+error: invalid IP address syntax
+  --> tests/fail_nightly/iprange.rs:11:34
+   |
+11 |     let _ = iprange!("10.0.0.0", "10.0.0255");
+   |                                  ^^^^^^^^^^^

--- a/tests/fail_nightly/iprange4.rs
+++ b/tests/fail_nightly/iprange4.rs
@@ -1,0 +1,8 @@
+use const_addrs::iprange4;
+
+fn main() {
+    let _ = iprange4!("10.0.01", "10.0.1.0");
+    let _ = iprange4!("10.0.0.1", "10.0.10");
+    let _ = iprange4!("10.0.01", "10.0.10");
+    let _ = iprange4!("10.0.0.1", "2001:db8::32:23");
+}

--- a/tests/fail_nightly/iprange4.stderr
+++ b/tests/fail_nightly/iprange4.stderr
@@ -1,0 +1,29 @@
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange4.rs:4:23
+  |
+4 |     let _ = iprange4!("10.0.01", "10.0.1.0");
+  |                       ^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange4.rs:5:35
+  |
+5 |     let _ = iprange4!("10.0.0.1", "10.0.10");
+  |                                   ^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange4.rs:6:23
+  |
+6 |     let _ = iprange4!("10.0.01", "10.0.10");
+  |                       ^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange4.rs:6:34
+  |
+6 |     let _ = iprange4!("10.0.01", "10.0.10");
+  |                                  ^^^^^^^^^
+
+error: Addr is IPv6 but IPv4 is expected
+ --> tests/fail_nightly/iprange4.rs:7:35
+  |
+7 |     let _ = iprange4!("10.0.0.1", "2001:db8::32:23");
+  |                                   ^^^^^^^^^^^^^^^^^

--- a/tests/fail_nightly/iprange6.rs
+++ b/tests/fail_nightly/iprange6.rs
@@ -1,0 +1,9 @@
+use const_addrs::iprange6;
+
+fn main() {
+    let _ = iprange6!("2001:db8::32:23", "2001:db8::32::ffff");
+    let _ = iprange6!("2001:db8::32::23", "2001:db8::32:ffff");
+    let _ = iprange6!("2001:db8::32::23", "2001:db8::32::ffff");
+    let _ = iprange6!("2001:db8::32:23", "10.0.0.2");
+    let _ = iprange6!("10.0.0.1", "2001:db8::32:23");
+}

--- a/tests/fail_nightly/iprange6.stderr
+++ b/tests/fail_nightly/iprange6.stderr
@@ -1,0 +1,35 @@
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange6.rs:4:42
+  |
+4 |     let _ = iprange6!("2001:db8::32:23", "2001:db8::32::ffff");
+  |                                          ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange6.rs:5:23
+  |
+5 |     let _ = iprange6!("2001:db8::32::23", "2001:db8::32:ffff");
+  |                       ^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange6.rs:6:23
+  |
+6 |     let _ = iprange6!("2001:db8::32::23", "2001:db8::32::ffff");
+  |                       ^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/iprange6.rs:6:43
+  |
+6 |     let _ = iprange6!("2001:db8::32::23", "2001:db8::32::ffff");
+  |                                           ^^^^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail_nightly/iprange6.rs:7:42
+  |
+7 |     let _ = iprange6!("2001:db8::32:23", "10.0.0.2");
+  |                                          ^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail_nightly/iprange6.rs:8:23
+  |
+8 |     let _ = iprange6!("10.0.0.1", "2001:db8::32:23");
+  |                       ^^^^^^^^^^

--- a/tests/fail_nightly/ipsubnets.rs
+++ b/tests/fail_nightly/ipsubnets.rs
@@ -1,0 +1,17 @@
+use const_addrs::ipsubnets;
+
+fn main() {
+    let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32::ffff", 48);
+    let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32:ffff", 48);
+    let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32::ffff", 48);
+    let _ = ipsubnets!("2001:db8::32:23", "10.0.0.2", 48);
+    let _ = ipsubnets!("10.0.0.1", "2001:db8::32:23", 48);
+    let _ = ipsubnets!("2001:db8::32:23", "10.0.0.1", 48);
+    let _ = ipsubnets!("100.0.0", "10.0.0.255", 48);
+    let _ = ipsubnets!("10.0.0.0", "10.0.0255", 24);
+    let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32:ffff", 129);
+    let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32:ffff", 260);
+
+    let _ = ipsubnets!("10.0.0.1", "10.0.10.1", 33);
+    let _ = ipsubnets!("10.0.0.1", "10.0.10.1", 260);
+}

--- a/tests/fail_nightly/ipsubnets.stderr
+++ b/tests/fail_nightly/ipsubnets.stderr
@@ -1,0 +1,101 @@
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets.rs:4:43
+  |
+4 |     let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32::ffff", 48);
+  |                                           ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets.rs:5:24
+  |
+5 |     let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32:ffff", 48);
+  |                        ^^^^^^^^^^^^^^^^^^
+
+error: Minimum prefix must be 32 or less
+ --> tests/fail_nightly/ipsubnets.rs:5:65
+  |
+5 |     let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32:ffff", 48);
+  |                                                                 ^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets.rs:6:24
+  |
+6 |     let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32::ffff", 48);
+  |                        ^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets.rs:6:44
+  |
+6 |     let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32::ffff", 48);
+  |                                            ^^^^^^^^^^^^^^^^^^^^
+
+error: Minimum prefix must be 32 or less
+ --> tests/fail_nightly/ipsubnets.rs:6:66
+  |
+6 |     let _ = ipsubnets!("2001:db8::32::23", "2001:db8::32::ffff", 48);
+  |                                                                  ^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail_nightly/ipsubnets.rs:7:43
+  |
+7 |     let _ = ipsubnets!("2001:db8::32:23", "10.0.0.2", 48);
+  |                                           ^^^^^^^^^^
+
+error: Addr is IPv6 but IPv4 is expected
+ --> tests/fail_nightly/ipsubnets.rs:8:36
+  |
+8 |     let _ = ipsubnets!("10.0.0.1", "2001:db8::32:23", 48);
+  |                                    ^^^^^^^^^^^^^^^^^
+
+error: Minimum prefix must be 32 or less
+ --> tests/fail_nightly/ipsubnets.rs:8:55
+  |
+8 |     let _ = ipsubnets!("10.0.0.1", "2001:db8::32:23", 48);
+  |                                                       ^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail_nightly/ipsubnets.rs:9:43
+  |
+9 |     let _ = ipsubnets!("2001:db8::32:23", "10.0.0.1", 48);
+  |                                           ^^^^^^^^^^
+
+error: invalid IP address syntax
+  --> tests/fail_nightly/ipsubnets.rs:10:24
+   |
+10 |     let _ = ipsubnets!("100.0.0", "10.0.0.255", 48);
+   |                        ^^^^^^^^^
+
+error: Minimum prefix must be 32 or less
+  --> tests/fail_nightly/ipsubnets.rs:10:49
+   |
+10 |     let _ = ipsubnets!("100.0.0", "10.0.0.255", 48);
+   |                                                 ^^
+
+error: invalid IP address syntax
+  --> tests/fail_nightly/ipsubnets.rs:11:36
+   |
+11 |     let _ = ipsubnets!("10.0.0.0", "10.0.0255", 24);
+   |                                    ^^^^^^^^^^^
+
+error: Minimum prefix must be 128 or less
+  --> tests/fail_nightly/ipsubnets.rs:12:64
+   |
+12 |     let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32:ffff", 129);
+   |                                                                ^^^
+
+error: number too large to fit in target type
+  --> tests/fail_nightly/ipsubnets.rs:13:64
+   |
+13 |     let _ = ipsubnets!("2001:db8::32:23", "2001:db8::32:ffff", 260);
+   |                                                                ^^^
+
+error: Minimum prefix must be 32 or less
+  --> tests/fail_nightly/ipsubnets.rs:15:49
+   |
+15 |     let _ = ipsubnets!("10.0.0.1", "10.0.10.1", 33);
+   |                                                 ^^
+
+error: number too large to fit in target type
+  --> tests/fail_nightly/ipsubnets.rs:16:49
+   |
+16 |     let _ = ipsubnets!("10.0.0.1", "10.0.10.1", 260);
+   |                                                 ^^^

--- a/tests/fail_nightly/ipsubnets4.rs
+++ b/tests/fail_nightly/ipsubnets4.rs
@@ -1,0 +1,10 @@
+use const_addrs::ipsubnets4;
+
+fn main() {
+    let _ = ipsubnets4!("10.0.01", "10.0.1.0", 24);
+    let _ = ipsubnets4!("10.0.0.1", "10.0.10", 24);
+    let _ = ipsubnets4!("10.0.01", "10.0.10", 24);
+    let _ = ipsubnets4!("10.0.0.1", "2001:db8::32:23", 24);
+    let _ = ipsubnets4!("10.0.0.1", "10.0.10.0", 33);
+    let _ = ipsubnets4!("10.0.0.1", "10.0.10.0", 260);
+}

--- a/tests/fail_nightly/ipsubnets4.stderr
+++ b/tests/fail_nightly/ipsubnets4.stderr
@@ -1,0 +1,41 @@
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets4.rs:4:25
+  |
+4 |     let _ = ipsubnets4!("10.0.01", "10.0.1.0", 24);
+  |                         ^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets4.rs:5:37
+  |
+5 |     let _ = ipsubnets4!("10.0.0.1", "10.0.10", 24);
+  |                                     ^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets4.rs:6:25
+  |
+6 |     let _ = ipsubnets4!("10.0.01", "10.0.10", 24);
+  |                         ^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets4.rs:6:36
+  |
+6 |     let _ = ipsubnets4!("10.0.01", "10.0.10", 24);
+  |                                    ^^^^^^^^^
+
+error: Addr is IPv6 but IPv4 is expected
+ --> tests/fail_nightly/ipsubnets4.rs:7:37
+  |
+7 |     let _ = ipsubnets4!("10.0.0.1", "2001:db8::32:23", 24);
+  |                                     ^^^^^^^^^^^^^^^^^
+
+error: Minimum prefix must be 32 or less
+ --> tests/fail_nightly/ipsubnets4.rs:8:50
+  |
+8 |     let _ = ipsubnets4!("10.0.0.1", "10.0.10.0", 33);
+  |                                                  ^^
+
+error: number too large to fit in target type
+ --> tests/fail_nightly/ipsubnets4.rs:9:50
+  |
+9 |     let _ = ipsubnets4!("10.0.0.1", "10.0.10.0", 260);
+  |                                                  ^^^

--- a/tests/fail_nightly/ipsubnets6.rs
+++ b/tests/fail_nightly/ipsubnets6.rs
@@ -1,0 +1,11 @@
+use const_addrs::ipsubnets6;
+
+fn main() {
+    let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32:ffff", 24);
+    let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32::ffff", 24);
+    let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32::ffff", 24);
+    let _ = ipsubnets6!("2001:db8::32:23", "10.0.0.1", 24);
+    let _ = ipsubnets6!("10.0.0.1", "2001:db8::32:ffff", 129);
+    let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32:ffff", 129);
+    let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32:ffff", 260);
+}

--- a/tests/fail_nightly/ipsubnets6.stderr
+++ b/tests/fail_nightly/ipsubnets6.stderr
@@ -1,0 +1,53 @@
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets6.rs:4:25
+  |
+4 |     let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32:ffff", 24);
+  |                         ^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets6.rs:5:44
+  |
+5 |     let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32::ffff", 24);
+  |                                            ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets6.rs:6:25
+  |
+6 |     let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32::ffff", 24);
+  |                         ^^^^^^^^^^^^^^^^^^
+
+error: invalid IP address syntax
+ --> tests/fail_nightly/ipsubnets6.rs:6:45
+  |
+6 |     let _ = ipsubnets6!("2001:db8::32::23", "2001:db8::32::ffff", 24);
+  |                                             ^^^^^^^^^^^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail_nightly/ipsubnets6.rs:7:44
+  |
+7 |     let _ = ipsubnets6!("2001:db8::32:23", "10.0.0.1", 24);
+  |                                            ^^^^^^^^^^
+
+error: Addr is IPv4 but IPv6 is expected
+ --> tests/fail_nightly/ipsubnets6.rs:8:25
+  |
+8 |     let _ = ipsubnets6!("10.0.0.1", "2001:db8::32:ffff", 129);
+  |                         ^^^^^^^^^^
+
+error: Minimum prefix must be 128 or less
+ --> tests/fail_nightly/ipsubnets6.rs:8:58
+  |
+8 |     let _ = ipsubnets6!("10.0.0.1", "2001:db8::32:ffff", 129);
+  |                                                          ^^^
+
+error: Minimum prefix must be 128 or less
+ --> tests/fail_nightly/ipsubnets6.rs:9:65
+  |
+9 |     let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32:ffff", 129);
+  |                                                                 ^^^
+
+error: number too large to fit in target type
+  --> tests/fail_nightly/ipsubnets6.rs:10:65
+   |
+10 |     let _ = ipsubnets6!("2001:db8::32:23", "2001:db8::32:ffff", 260);
+   |                                                                 ^^^

--- a/tests/pass/iprange.rs
+++ b/tests/pass/iprange.rs
@@ -1,0 +1,26 @@
+use ipnet::{IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
+
+use const_addrs::{ip4, ip6, iprange};
+
+fn main() {
+    let a = iprange!("192.168.1.1", "192.168.1.254");
+    match a {
+        IpAddrRange::V4(net) => {
+            assert_eq!(
+                net,
+                Ipv4AddrRange::new(ip4!("192.168.1.1"), ip4!("192.168.1.254"))
+            );
+        }
+        _ => panic!("should not be v6"),
+    }
+    let b = iprange!("2001:db8::32:23", "2001:db8::32:ffff");
+    match b {
+        IpAddrRange::V6(net) => {
+            assert_eq!(
+                net,
+                Ipv6AddrRange::new(ip6!("2001:db8::32:23"), ip6!("2001:db8::32:ffff"))
+            );
+        }
+        _ => panic!("should not be v4"),
+    }
+}

--- a/tests/pass/iprange4.rs
+++ b/tests/pass/iprange4.rs
@@ -1,0 +1,11 @@
+use ipnet::Ipv4AddrRange;
+
+use const_addrs::{ip4, iprange4};
+
+fn main() {
+    let a = iprange4!("192.168.1.1", "192.168.1.254");
+    assert_eq!(
+        a,
+        Ipv4AddrRange::new(ip4!("192.168.1.1"), ip4!("192.168.1.254"))
+    );
+}

--- a/tests/pass/iprange6.rs
+++ b/tests/pass/iprange6.rs
@@ -1,0 +1,11 @@
+use ipnet::Ipv6AddrRange;
+
+use const_addrs::{ip6, iprange6};
+
+fn main() {
+    let b = iprange6!("2001:db8::32:23", "2001:db8::32:ffff");
+    assert_eq!(
+        b,
+        Ipv6AddrRange::new(ip6!("2001:db8::32:23"), ip6!("2001:db8::32:ffff"))
+    );
+}

--- a/tests/pass/ipsubnets.rs
+++ b/tests/pass/ipsubnets.rs
@@ -1,0 +1,26 @@
+use ipnet::{IpSubnets, Ipv4Subnets, Ipv6Subnets};
+
+use const_addrs::{ip4, ip6, ipsubnets};
+
+fn main() {
+    let a = ipsubnets!("192.168.1.1", "192.168.1.254", 30);
+    match a {
+        IpSubnets::V4(net) => {
+            assert_eq!(
+                net,
+                Ipv4Subnets::new(ip4!("192.168.1.1"), ip4!("192.168.1.254"), 30)
+            );
+        }
+        _ => panic!("should not be v6"),
+    }
+    let b = ipsubnets!("2001:db8::32:23", "2001:db8::32:ffff", 120);
+    match b {
+        IpSubnets::V6(net) => {
+            assert_eq!(
+                net,
+                Ipv6Subnets::new(ip6!("2001:db8::32:23"), ip6!("2001:db8::32:ffff"), 120)
+            );
+        }
+        _ => panic!("should not be v4"),
+    }
+}

--- a/tests/pass/ipsubnets4.rs
+++ b/tests/pass/ipsubnets4.rs
@@ -1,0 +1,11 @@
+use ipnet::Ipv4Subnets;
+
+use const_addrs::{ip4, ipsubnets4};
+
+fn main() {
+    let a = ipsubnets4!("192.168.1.1", "192.168.1.254", 30);
+    assert_eq!(
+        a,
+        Ipv4Subnets::new(ip4!("192.168.1.1"), ip4!("192.168.1.254"), 30)
+    );
+}

--- a/tests/pass/ipsubnets6.rs
+++ b/tests/pass/ipsubnets6.rs
@@ -1,0 +1,11 @@
+use ipnet::Ipv6Subnets;
+
+use const_addrs::{ip6, ipsubnets6};
+
+fn main() {
+    let b = ipsubnets6!("2001:db8::32:23", "2001:db8::32:ffff", 122);
+    assert_eq!(
+        b,
+        Ipv6Subnets::new(ip6!("2001:db8::32:23"), ip6!("2001:db8::32:ffff"), 122)
+    );
+}

--- a/tests/warnings/iprange.rs
+++ b/tests/warnings/iprange.rs
@@ -1,0 +1,9 @@
+use const_addrs::iprange;
+
+fn main() {
+    let _ = iprange!("2001:db8::32:ffff", "2001:db8::32:23");
+    let _ = iprange!("10.128.0.0", "10.0.0.0");
+
+    //failure so the output is compared
+    let _ = iprange!("10128.0.0", "10.0.0.0");
+}

--- a/tests/warnings/iprange.stderr
+++ b/tests/warnings/iprange.stderr
@@ -1,0 +1,21 @@
+warning: This range will yeild no values: IP1 >= IP2
+ --> tests/warnings/iprange.rs:4:22
+  |
+4 |     let _ = iprange!("2001:db8::32:ffff", "2001:db8::32:23");
+  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: This iterator requires the lower IP value first in it's arguments list.
+
+warning: This range will yeild no values: IP1 >= IP2
+ --> tests/warnings/iprange.rs:5:22
+  |
+5 |     let _ = iprange!("10.128.0.0", "10.0.0.0");
+  |                      ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: This iterator requires the lower IP value first in it's arguments list.
+
+error: invalid IP address syntax
+ --> tests/warnings/iprange.rs:8:22
+  |
+8 |     let _ = iprange!("10128.0.0", "10.0.0.0");
+  |                      ^^^^^^^^^^^

--- a/tests/warnings/iprange4.rs
+++ b/tests/warnings/iprange4.rs
@@ -1,0 +1,8 @@
+use const_addrs::iprange4;
+
+fn main() {
+    let _ = iprange4!("10.0.1.0", "10.0.0.0");
+
+    // failure so output is compared
+    let _ = iprange4!("10.0.10", "10.0.0.0");
+}

--- a/tests/warnings/iprange4.stderr
+++ b/tests/warnings/iprange4.stderr
@@ -1,0 +1,13 @@
+warning: This range will yeild no values: IP1 >= IP2
+ --> tests/warnings/iprange4.rs:4:23
+  |
+4 |     let _ = iprange4!("10.0.1.0", "10.0.0.0");
+  |                       ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: This iterator requires the lower IP value first in it's arguments list.
+
+error: invalid IP address syntax
+ --> tests/warnings/iprange4.rs:7:23
+  |
+7 |     let _ = iprange4!("10.0.10", "10.0.0.0");
+  |                       ^^^^^^^^^

--- a/tests/warnings/iprange6.rs
+++ b/tests/warnings/iprange6.rs
@@ -1,0 +1,8 @@
+use const_addrs::iprange6;
+
+fn main() {
+    let _ = iprange6!("2001:db8::32:ffff", "2001:db8::32:23");
+
+    // bad one just to fail the compilation and compare output
+    let _ = iprange6!("2001:db8::32::ffff", "2001:db8::32:23");
+}

--- a/tests/warnings/iprange6.stderr
+++ b/tests/warnings/iprange6.stderr
@@ -1,0 +1,13 @@
+warning: This range will yeild no values: IP1 >= IP2
+ --> tests/warnings/iprange6.rs:4:23
+  |
+4 |     let _ = iprange6!("2001:db8::32:ffff", "2001:db8::32:23");
+  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: This iterator requires the lower IP value first in it's arguments list.
+
+error: invalid IP address syntax
+ --> tests/warnings/iprange6.rs:7:23
+  |
+7 |     let _ = iprange6!("2001:db8::32::ffff", "2001:db8::32:23");
+  |                       ^^^^^^^^^^^^^^^^^^^^

--- a/tests/warnings/ipsubnets.rs
+++ b/tests/warnings/ipsubnets.rs
@@ -1,0 +1,9 @@
+use const_addrs::ipsubnets;
+
+fn main() {
+    let _ = ipsubnets!("2001:db8::32:ffff", "2001:db8::32:23", 64);
+    let _ = ipsubnets!("10.128.0.0", "10.0.0.0", 24);
+
+    //failure so the output is compared
+    let _ = ipsubnets!("10128.0.0", "10.0.0.0", 24);
+}

--- a/tests/warnings/ipsubnets.stderr
+++ b/tests/warnings/ipsubnets.stderr
@@ -1,0 +1,21 @@
+warning: This range will yeild no values: IP1 >= IP2
+ --> tests/warnings/ipsubnets.rs:4:24
+  |
+4 |     let _ = ipsubnets!("2001:db8::32:ffff", "2001:db8::32:23", 64);
+  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: This iterator requires the lower IP value first in it's arguments list.
+
+warning: This range will yeild no values: IP1 >= IP2
+ --> tests/warnings/ipsubnets.rs:5:24
+  |
+5 |     let _ = ipsubnets!("10.128.0.0", "10.0.0.0", 24);
+  |                        ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: This iterator requires the lower IP value first in it's arguments list.
+
+error: invalid IP address syntax
+ --> tests/warnings/ipsubnets.rs:8:24
+  |
+8 |     let _ = ipsubnets!("10128.0.0", "10.0.0.0", 24);
+  |                        ^^^^^^^^^^^

--- a/tests/warnings/ipsubnets4.rs
+++ b/tests/warnings/ipsubnets4.rs
@@ -1,0 +1,8 @@
+use const_addrs::ipsubnets4;
+
+fn main() {
+    let _ = ipsubnets4!("10.0.1.0", "10.0.0.0", 24);
+
+    // failure so output is compared
+    let _ = ipsubnets4!("10.0.10", "10.0.0.0", 24);
+}

--- a/tests/warnings/ipsubnets4.stderr
+++ b/tests/warnings/ipsubnets4.stderr
@@ -1,0 +1,13 @@
+warning: This range will yeild no values: IP1 >= IP2
+ --> tests/warnings/ipsubnets4.rs:4:25
+  |
+4 |     let _ = ipsubnets4!("10.0.1.0", "10.0.0.0", 24);
+  |                         ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: This iterator requires the lower IP value first in it's arguments list.
+
+error: invalid IP address syntax
+ --> tests/warnings/ipsubnets4.rs:7:25
+  |
+7 |     let _ = ipsubnets4!("10.0.10", "10.0.0.0", 24);
+  |                         ^^^^^^^^^

--- a/tests/warnings/ipsubnets6.rs
+++ b/tests/warnings/ipsubnets6.rs
@@ -1,0 +1,8 @@
+use const_addrs::ipsubnets6;
+
+fn main() {
+    let _ = ipsubnets6!("2001:db8::32:ffff", "2001:db8::32:23", 64);
+
+    // bad one just to fail the compilation and compare output
+    let _ = ipsubnets6!("2001:db8::32::ffff", "2001:db8::32:23", 64);
+}

--- a/tests/warnings/ipsubnets6.stderr
+++ b/tests/warnings/ipsubnets6.stderr
@@ -1,0 +1,13 @@
+warning: This range will yeild no values: IP1 >= IP2
+ --> tests/warnings/ipsubnets6.rs:4:25
+  |
+4 |     let _ = ipsubnets6!("2001:db8::32:ffff", "2001:db8::32:23", 64);
+  |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: This iterator requires the lower IP value first in it's arguments list.
+
+error: invalid IP address syntax
+ --> tests/warnings/ipsubnets6.rs:7:25
+  |
+7 |     let _ = ipsubnets6!("2001:db8::32::ffff", "2001:db8::32:23", 64);
+  |                         ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### This PR:
Add support for additional ipnet types

This involves a couple of things:

* support for IpRange types and IpSubnets types. These are not simple
   fromstr implementations so the make_macro! approach didn't work.
    Instead a heck of a lot of proc-macro code was needed to parse and
   validate the args lists.

* A separate set of tests for nightly vs stable builds in some cases.
   Reasons for this:
      1) compiler output is slightly different between nightly and stable.
      2) there is warning support in nightly and this emits warnings when
         the generated iterators might behave different than expected.

 Fixes: #21 


### Checklist:

<!-- A reminder of the things that should be done for each PR -->

- [x] Tests provided for new functionality
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Changelog reflects this change
- [x] Docs/README are updated appropraitely (if applicable)

